### PR TITLE
Move @ember/test-helpers and qunit into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "ember-uuid": "^2.0.0",
     "fs-extra": "^8.0.1",
     "json-stable-stringify": "^1.0.1",
-    "lodash": "^4.17.11",
-    "qunit": "2.14.0"
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
@@ -65,6 +64,7 @@
     "eslint-plugin-node": "^9.0.1",
     "loader.js": "^4.7.0",
     "mocha": "^5.2.0",
+    "qunit": "2.14.0",
     "qunit-dom": "^1.6.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "test:node": "mocha 'node-tests/**/*-test.js'"
   },
   "dependencies": {
-    "@ember/test-helpers": "2.1.4",
     "@pact-foundation/pact-node": "^8.4.0",
     "body-parser": "^1.19.0",
     "broccoli-funnel": "^2.0.2",
@@ -38,6 +37,7 @@
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^0.7.0",
+    "@ember/test-helpers": "2.1.4",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
Having `@ember/test-helpers` in dependencies is causing issues with embroider. I think it makes more sense to have it in devDependencies anyways. I've also moved qunit. Having qunit in dependencies is causing magnum to install two versions of qunit (2.14.0 and 2.19.1).

I've tested the changes with magnum already (https://github.com/freshbooks/magnum-ui/pull/11252) and it appears that the pact tests continue to run fine.