### PR TITLE
Update serializeMatchingRules export to fix warning

### DIFF
--- a/addon-test-support/-private/serialization/index.js
+++ b/addon-test-support/-private/serialization/index.js
@@ -1,3 +1,3 @@
-export { default as serializeMatchingRules } from './utils';
+export { serializeMatchingRules } from './utils';
 export { default as serializeV2 } from './v2';
 export { default as serializeV3 } from './v3';


### PR DESCRIPTION
This should hopefully fix this warning:
```
WARNING in ./node_modules/ember-cli-pact/-private/serialization/index.js 1:0-60
export 'default' (reexported as 'serializeMatchingRules') was not found in './utils' (possible exports: applyBody, applyMatchingRules, createPactSkeleton, serializeMatchingRules)
 @ ./node_modules/ember-cli-pact/-private/interaction.js 2:0-59 29:13-24 31:13-24
 @ ./node_modules/ember-cli-pact/mock-provider/index.js 5:0-50 39:27-38
 @ ./tests/helpers/pact-providers/pretender.js 2:0-56 3:47-59
 @ ./assets/test.js 947:13-68
```